### PR TITLE
feat(format-and-lint): adding new fields, linting existing code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tavily/core",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tavily/core",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tavily/core",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Official JavaScript library for Tavily.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/crawl.ts
+++ b/src/crawl.ts
@@ -12,7 +12,7 @@ export function _crawl(
 ): TavilyCrawlFunction {
   return async function crawl(
     url: string,
-    options: Partial<TavilyCrawlOptions> = {}
+    options: Partial<TavilyCrawlOptions>
   ) {
     const {
       maxDepth,
@@ -27,9 +27,12 @@ export function _crawl(
       includeImages,
       categories,
       instructions,
+      format,
+      timeout,
       ...kwargs
     } = options;
-    const timeout = options?.timeout ? Math.min(options.timeout, 120) : 60; // Max 120s, default to 60
+
+    const requestTimeout = timeout ? Math.min(timeout, 120) : 60; // Max 120s, default to 60
 
     try {
       const response = await post(
@@ -38,7 +41,7 @@ export function _crawl(
           url: url,
           max_depth: maxDepth,
           max_breadth: maxBreadth,
-          limit: limit,
+          limit,
           extract_depth: extractDepth,
           select_paths: selectPaths,
           select_domains: selectDomains,
@@ -46,13 +49,14 @@ export function _crawl(
           exclude_domains: excludeDomains,
           allow_external: allowExternal,
           include_images: includeImages,
-          categories: categories,
-          instructions: instructions,
+          categories,
+          instructions,
+          format,
           ...kwargs,
         },
         apiKey,
         proxies,
-        timeout
+        requestTimeout
       );
 
       return {
@@ -69,7 +73,7 @@ export function _crawl(
     } catch (err) {
       if (err instanceof AxiosError) {
         if (err.code === "ECONNABORTED") {
-          handleTimeoutError(timeout);
+          handleTimeoutError(requestTimeout);
         }
         if (err.response) {
           handleRequestError(err.response as AxiosResponse);

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -12,16 +12,11 @@ export function _extract(
 ): TavilyExtractFunction {
   return async function extract(
     urls: Array<string>,
-    options: TavilyExtractOptions = {
-      includeImages: false,
-      extractDepth: "basic",
-      timeout: 60,
-    }
+    options: Partial<TavilyExtractOptions>
   ) {
-    const { includeImages, extractDepth, ...kwargs } = options;
-    let { timeout } = options;
+    const { includeImages, extractDepth, format, timeout, ...kwargs } = options;
 
-    timeout = timeout ? Math.min(timeout, 120) : 60; // Max 120s, default to 60
+    const requestTimeout = timeout ? Math.min(timeout, 120) : 60; // Max 120s, default to 60
 
     try {
       const response = await post(
@@ -30,11 +25,12 @@ export function _extract(
           urls,
           include_images: includeImages,
           extract_depth: extractDepth,
+          format,
           ...kwargs,
         },
         apiKey,
         proxies,
-        timeout
+        requestTimeout
       );
 
       return {
@@ -56,7 +52,7 @@ export function _extract(
     } catch (err) {
       if (err instanceof AxiosError) {
         if (err.code === "ECONNABORTED") {
-          handleTimeoutError(timeout);
+          handleTimeoutError(requestTimeout);
         }
         if (err.response) {
           handleRequestError(err.response as AxiosResponse);

--- a/src/map.ts
+++ b/src/map.ts
@@ -10,10 +10,7 @@ export function _map(
   apiKey: string,
   proxies?: TavilyProxyOptions
 ): TavilyMapFunction {
-  return async function map(
-    url: string,
-    options: Partial<TavilyMapOptions> = {}
-  ) {
+  return async function map(url: string, options: Partial<TavilyMapOptions>) {
     const {
       maxDepth,
       maxBreadth,
@@ -25,10 +22,11 @@ export function _map(
       allowExternal,
       categories,
       instructions,
+      timeout,
       ...kwargs
     } = options;
 
-    const timeout = options?.timeout ? Math.min(options.timeout, 120) : 60; // Max 120s, default to 60
+    const requestTimeout = timeout ? Math.min(timeout, 120) : 60; // Max 120s, default to 60
 
     try {
       const response = await post(
@@ -37,19 +35,19 @@ export function _map(
           url: url,
           max_depth: maxDepth,
           max_breadth: maxBreadth,
-          limit: limit,
+          limit,
           select_paths: selectPaths,
           select_domains: selectDomains,
           exclude_paths: excludePaths,
           exclude_domains: excludeDomains,
           allow_external: allowExternal,
-          categories: categories,
-          instructions: instructions,
+          categories,
+          instructions,
           ...kwargs,
         },
         apiKey,
         proxies,
-        timeout
+        requestTimeout
       );
 
       return {
@@ -60,7 +58,7 @@ export function _map(
     } catch (err) {
       if (err instanceof AxiosError) {
         if (err.code === "ECONNABORTED") {
-          handleTimeoutError(timeout);
+          handleTimeoutError(requestTimeout);
         }
         if (err.response) {
           handleRequestError(err.response as AxiosResponse);

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,7 +55,7 @@ export type TavilySearchOptions = {
   includeImages?: boolean;
   includeImageDescriptions?: boolean;
   includeAnswer?: boolean;
-  includeRawContent?: boolean;
+  includeRawContent?: false | "markdown" | "text";
   includeDomains?: string[];
   excludeDomains?: string[];
   maxTokens?: number;
@@ -91,6 +91,7 @@ export type TavilySearchResponse = {
 export type TavilyExtractOptions = {
   includeImages?: boolean;
   extractDepth?: "basic" | "advanced";
+  format?: "markdown" | "text";
   timeout?: number;
   [key: string]: any;
 };
@@ -139,19 +140,20 @@ export type TavilyExtractResponse = {
 };
 
 export type TavilyCrawlOptions = {
-  maxDepth: number;
-  maxBreadth: number;
-  limit: number;
-  instructions: string;
-  extractDepth: "basic" | "advanced";
-  selectPaths: string[];
-  selectDomains: string[];
-  excludePaths: string[];
-  excludeDomains: string[];
-  allowExternal: boolean;
-  includeImages: boolean;
-  categories: TavilyCrawlCategory[];
-  timeout: number;
+  maxDepth?: number;
+  maxBreadth?: number;
+  limit?: number;
+  instructions?: string;
+  extractDepth?: "basic" | "advanced";
+  selectPaths?: string[];
+  selectDomains?: string[];
+  excludePaths?: string[];
+  excludeDomains?: string[];
+  allowExternal?: boolean;
+  includeImages?: boolean;
+  categories?: TavilyCrawlCategory[];
+  format?: "markdown" | "text";
+  timeout?: number;
   [key: string]: any;
 };
 
@@ -166,17 +168,17 @@ export type TavilyCrawlResponse = {
 };
 
 export type TavilyMapOptions = {
-  limit: number;
-  maxDepth: number;
-  maxBreadth: number;
-  selectPaths: string[];
-  selectDomains: string[];
-  excludePaths: string[];
-  excludeDomains: string[];
-  categories: TavilyCrawlCategory[];
-  allowExternal: boolean;
-  instructions: string;
-  timeout: number;
+  limit?: number;
+  maxDepth?: number;
+  maxBreadth?: number;
+  selectPaths?: string[];
+  selectDomains?: string[];
+  excludePaths?: string[];
+  excludeDomains?: string[];
+  categories?: TavilyCrawlCategory[];
+  allowExternal?: boolean;
+  instructions?: string;
+  timeout?: number;
   [key: string]: any;
 };
 


### PR DESCRIPTION
- Adds `format` to crawl and extract, changes type of `include_raw_content` in search
- Makes the fields in the crawl and map options parameter optional
- Refactors default values
- Modifies timeout logic to avoid passing as kwarg