### PR TITLE
feat: add exactMatch parameter to search

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ const response = await tvly.search("Who is Leo Messi?");
 console.log(response);
 ```
 
+### Using exact match to find specific names or phrases
+
+```javascript
+const { tavily } = require("@tavily/core");
+
+const tvly = tavily({ apiKey: "tvly-YOUR_API_KEY" });
+
+// Use exactMatch: true to only return results containing the exact phrase(s) inside quotes
+const response = await tvly.search('"John Smith" CEO Acme Corp', {
+  exactMatch: true,
+});
+console.log(response);
+```
+
 > To learn more about the different parameters, head to our [JavaScript API Reference](https://docs.tavily.com/sdk/reference/javascript).
 
 # Tavily Extract

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tavily/core",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Official JavaScript library for Tavily.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/search.ts
+++ b/src/search.ts
@@ -39,6 +39,7 @@ export function _search(requestConfig: TavilyRequestConfig): TavilySearchFuncton
       timeout,
       includeFavicon,
       includeUsage,
+      exactMatch,
       ...kwargs
     } = options;
 
@@ -67,6 +68,7 @@ export function _search(requestConfig: TavilyRequestConfig): TavilySearchFuncton
           auto_parameters: autoParameters,
           include_favicon: includeFavicon,
           include_usage: includeUsage,
+          exact_match: exactMatch,
           ...kwargs,
         },
         requestConfig,

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,7 @@ export type TavilySearchOptions = {
   timeout?: number;
   includeFavicon?: boolean;
   includeUsage?: boolean;
+  exactMatch?: boolean;
   [key: string]: any;
 };
 


### PR DESCRIPTION
## Summary
- Add `exactMatch` (boolean, optional) to `TavilySearchOptions` type
- Destructure and convert to `exact_match` in the search request payload
- Bump version to 0.7.2
- Update README with usage example

Fixes TAV-5096

## Test plan
- [x] TypeScript compiles with no errors (`tsc --noEmit`)
- [x] Build succeeds (`npm run build`)
- [x] Parameter is correctly converted from camelCase (`exactMatch`) to snake_case (`exact_match`) in the API request
- [x] Omitting the parameter does not send it (undefined values not included by axios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)