### PR TITLE
fix: pin axios to 1.14.0 — supply chain attack mitigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.7.7",
+        "axios": "1.14.0",
         "https-proxy-agent": "^7.0.6",
         "js-tiktoken": "^1.0.14"
       },
@@ -880,14 +880,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/base64-js": {
@@ -1082,6 +1082,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1411,6 +1412,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1470,9 +1472,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -1709,6 +1715,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
       "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -36,11 +36,12 @@
     "typescript": "^5.6.2"
   },
   "dependencies": {
-    "axios": "^1.7.7",
+    "axios": "1.14.0",
     "https-proxy-agent": "^7.0.6",
     "js-tiktoken": "^1.0.14"
   },
   "overrides": {
-    "esbuild": "^0.25.0"
+    "esbuild": "^0.25.0",
+    "axios": "1.14.0"
   }
 }


### PR DESCRIPTION
## Summary

- Pins `axios` direct dependency from `^1.7.7` to exact `1.14.0`
- Adds npm override to block compromised versions from transitive resolution

## Context

`axios@1.14.1` and `axios@0.30.4` were compromised with a malicious dependency (`plain-crypto-js@4.2.1`) that deploys a Remote Access Trojan (RAT) via a postinstall hook. The RAT targets macOS, Linux, and Windows and phones home to a C2 server.

Anyone running `npm install` with `@tavily/core` currently resolves `axios@^1.7.7` to the compromised `1.14.1`.

**Advisory:** https://www.aikido.dev/blog/axios-npm-compromised-maintainer-hijacked-rat

## Changes

- `package.json`: pin axios to exact `1.14.0`, add axios to existing npm overrides block

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin/override and lockfile refresh; low functional risk but affects install resolution and could surface compatibility issues if other deps expect newer `axios`.
> 
> **Overview**
> Pins the direct dependency on `axios` from a caret range to the exact `1.14.0`, and adds an npm `overrides` entry to force that version even when resolved transitively.
> 
> Updates `package-lock.json` accordingly (including `axios` and its `proxy-from-env` bump), ensuring installs don’t pick up compromised releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15ba80f064c3e6bb50a6e9f251e05e51cd516f29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->