### PR TITLE
fix(pkg): publish only dist/ via files allowlist (0.7.5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 .DS_Store
 .env
+
+# npm pack artifacts
+*.tgz

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tavily/core",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tavily/core",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@tavily/core",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Official JavaScript library for Tavily.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "import": "./dist/index.mjs",


### PR DESCRIPTION
## What

Adds an explicit `"files": ["dist"]` allowlist to `package.json` and bumps the version to `0.7.5`.

## Why

`@tavily/core@0.7.4` accidentally published two untracked, root-level scratch files:

- `test.ts` — **contains a hardcoded production API key** (`tvly-prod-test-…`), now publicly downloadable from the npm registry
- `tvly-js-sdk-test.js`

Neither file is committed to this repo — they were untracked files in the working tree of whoever ran `npm publish`. They leaked because packaging relied on a **denylist** `.npmignore`:

```
/src
/node_modules
/test          # matches the /test dir, not root-level test.ts
.DS_Store
.env
tsconfig.json
tsup.config.ts
```

A root-level `test.ts` / `tvly-js-sdk-test.js` matches nothing, and there was no `files` field, so npm packed them. With a denylist, **any** new file at the repo root gets published unless someone remembers to ignore it.

Scope: only `0.7.4` is affected. `0.7.0`–`0.7.3` tarballs are clean (verified).

## Fix

Switch from denylist to an explicit allowlist. `npm pack` now ships only `dist/` (plus npm's auto-included `README.md`, `LICENSE`, `package.json`) no matter what's in the working tree.

Verified by dropping the exact scratch files back into the working tree and running `npm pack --dry-run` — they are excluded:

```
1.1kB  LICENSE
10.1kB README.md
dist/index.d.mts / .d.ts / .js / .js.map / .mjs / .mjs.map
961B   package.json
```

## Out of band (not in this PR)

- [ ] **Rotate/revoke the exposed prod key** — required regardless; old tarballs persist in npm/mirrors even after deprecate/unpublish.
- [ ] `npm deprecate @tavily/core@0.7.4 "contains stray files; use 0.7.5"` after this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)