### PR TITLE
feat: optional orgId option (x-tavily-orgid header)

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -33,6 +33,7 @@ export function tavily(options?: TavilyClientOptions): TavilyClient {
     apiBaseURL: options?.apiBaseURL,
     clientSource: options?.clientSource,
     projectId: options?.projectId || process.env.TAVILY_PROJECT,
+    orgId: options?.orgId || process.env.TAVILY_ORG_ID,
     sessionId: options?.sessionId,
     humanId: options?.humanId,
     clientName: options?.clientName,

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,6 +71,7 @@ export type TavilyClientOptions = {
   apiBaseURL?: string;
   clientSource?: string;
   projectId?: string;
+  orgId?: string;
   sessionId?: string;
   humanId?: string;
   clientName?: string;
@@ -82,6 +83,7 @@ export type TavilyRequestConfig = {
   apiBaseURL?: string;
   clientSource?: string;
   projectId?: string;
+  orgId?: string;
   sessionId?: string;
   humanId?: string;
   clientName?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,7 +34,7 @@ function buildHeaders(requestConfig: TavilyRequestConfig): Record<string, string
   }
 
   if (projectId) headers["X-Project-ID"] = projectId;
-  if (orgId) headers["x-tavily-orgid"] = orgId;
+  if (orgId) headers["X-Tavily-Orgid"] = orgId;
   if (sessionId) headers["X-Session-Id"] = sessionId;
   if (humanId) headers["X-Human-Id"] = humanId;
   if (clientName) headers["X-Client-Name"] = clientName;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,7 +17,7 @@ type TavilyErrorData = {
 };
 
 function buildHeaders(requestConfig: TavilyRequestConfig): Record<string, string> {
-  const { apiKey, clientSource, projectId, sessionId, humanId, clientName } =
+  const { apiKey, clientSource, projectId, orgId, sessionId, humanId, clientName } =
     requestConfig;
   const isKeyless = !apiKey;
 
@@ -34,6 +34,7 @@ function buildHeaders(requestConfig: TavilyRequestConfig): Record<string, string
   }
 
   if (projectId) headers["X-Project-ID"] = projectId;
+  if (orgId) headers["x-tavily-orgid"] = orgId;
   if (sessionId) headers["X-Session-Id"] = sessionId;
   if (humanId) headers["X-Human-Id"] = humanId;
   if (clientName) headers["X-Client-Name"] = clientName;


### PR DESCRIPTION
## What

Adds an optional `orgId` field to `TavilyClientOptions` (with a `TAVILY_ORG_ID` environment variable fallback). When set, the client attaches an `x-tavily-orgid` header to every request.

## Why

This header lets the edge (WAF) apply per-organization rate limits by tier, instead of per key. SDK users pass their org id once on the client and the header is sent automatically; nothing changes for callers who don't set it.

## How

Mirrors the existing `projectId` / `X-Project-ID` handling: `orgId` is read in `tavily()` (or from `TAVILY_ORG_ID`), flows through `TavilyRequestConfig`, and `buildHeaders` adds the header only when it is set.

## Test

- `npm run build` passes (types compile).