### PR TITLE
chore: bump version to 0.7.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tavily/core",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tavily/core",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tavily/core",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Official JavaScript library for Tavily.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Bump package version from 0.7.5 to 0.7.6 in `package.json` and `package-lock.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)