### PR TITLE
feat(search): add per-result images to search results

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tavily/core",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tavily/core",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tavily/core",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "Official JavaScript library for Tavily.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/search.ts
+++ b/src/search.ts
@@ -109,6 +109,17 @@ export function _search(requestConfig: TavilyRequestConfig): TavilySearchFuncton
             publishedDate: result.published_date,
             favicon: result.favicon,
             id: result.id,
+            images: (Array.isArray(result.images) ? result.images : [])
+              .map((image: any) => ({
+                url: typeof image === "string" ? image : image?.url,
+                description:
+                  typeof image?.description === "string"
+                    ? image.description
+                    : undefined,
+              }))
+              .filter(({ url }: { url: unknown }) =>
+                typeof url === "string" && url.trim().length > 0
+              ),
           };
         }),
         answer: response.data.answer,

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,6 +139,7 @@ type TavilySearchResult = {
   publishedDate: string;
   favicon?: string;
   id: string;
+  images?: Array<TavilyImage>;
 };
 
 export type TavilySearchResponse = {


### PR DESCRIPTION
### What

- Maps `results[i].images` from the `/search` response onto each search result.
- Adds `images?: Array<TavilyImage>` to `TavilySearchResult`.

### Why

- `/search` returns per-result images when `include_images` is true, but the response mapper dropped the field, leaving only top-level `response.images`.
- Per-result images are needed as a source-specific fallback when a favicon is broken.

### How

- Images are normalized to `{ url, description }`, matching how top-level `images` are already mapped. The API returns bare URL strings unless `include_image_descriptions` is set, in which case it returns objects, so the field needs normalizing rather than passing through.
- Entries without a usable URL string are skipped, and a non-array `images` value yields `[]`.

```ts
const res = await client.search("query", { includeImages: true });
res.results[0].images?.[0]?.url;
```